### PR TITLE
add extra line to Rprofile

### DIFF
--- a/content/welcome/_index.en.md
+++ b/content/welcome/_index.en.md
@@ -67,6 +67,7 @@ An editor window will open up and instructions will be printed to your R console
 local({
   r <- getOption("repos")
   r["CRAN"] <- "https://cran.rstudio.com/"
+  r <- r[names(r) != "CRANextra"] # avoid a common error with MRAN installations
   options(repos = r)
 })
 ```


### PR DESCRIPTION
This avoids a common error from MRAN installations

```
 Error: Failed to install 'sitrep' from GitHub:
  Failed to install 'linelist' from GitHub:
  (converted from warning) unable to access index for repository http://www.stats.ox.ac.uk/pub/RWin/bin/windows/contrib/3.5:
  cannot open URL 'http://www.stats.ox.ac.uk/pub/RWin/bin/windows/contrib/3.5/PACKAGES'
```

It's common for MRAN to include a CRANextra URL that has links to packages that need some special treatment for installation.